### PR TITLE
Allow Plugin ID's greater than 5 digits

### DIFF
--- a/yanp.py
+++ b/yanp.py
@@ -280,7 +280,7 @@ class nessus_parser:
         """
         Search information by Nessus Plugin ID
         """
-        if len(pluginid) != 5 or not pluginid.isdigit():
+        if len(pluginid) < 5 or len(pluginid) > 6 or not pluginid.isdigit():
             print "[!] PluginID format error."
             exit(4)
         


### PR DESCRIPTION
Fix the assumption that Plugin ID's are 5 digits long resulting in a  'PluginID format error'  when a 6 digit value is specified.
There are now over 100000 plugins.  I've changed the validation to check for 5 or 6 digits which will take us up to Plugin ID 999999.